### PR TITLE
Filtered session and hashed passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .project
 .settings/org.eclipse.jdt.core.prefs
 .classpath
+start.sh

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,12 @@
   			<artifactId>hl7v2-fhir-converter</artifactId>
   			<version>1.0.10</version>
 		</dependency>
+		<dependency>
+			<groupId>org.mindrot</groupId>
+			<artifactId>jbcrypt</artifactId>
+			<version>0.4</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/immregistries/ehr/LoginFilter.java
+++ b/src/main/java/org/immregistries/ehr/LoginFilter.java
@@ -1,0 +1,46 @@
+package org.immregistries.ehr;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@WebFilter("/app/*")
+public class LoginFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig config) throws ServletException {
+        // If you have any <init-param> in web.xml, then you could get them
+        // here by config.getInitParameter("name") and assign it as field.
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+        HttpSession session = request.getSession(false);
+        String path = ((HttpServletRequest) request).getRequestURI();
+        if ((session == null || session.getAttribute("tester") == null) && !path.endsWith("authentication")) {
+            response.sendRedirect(request.getContextPath() + "/authentication"); 
+            // No logged-in user found, so redirect to login page.
+        } else {
+            chain.doFilter(req, res); // Logged-in user found, so just continue request.
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // If you have assigned any expensive resources as field of
+        // this Filter class, then you could clean/close them here.
+    }
+
+}

--- a/src/main/java/org/immregistries/ehr/servlet/Authentication.java
+++ b/src/main/java/org/immregistries/ehr/servlet/Authentication.java
@@ -16,6 +16,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.immregistries.ehr.model.Silo;
 import org.immregistries.ehr.model.Tester;
+import org.mindrot.jbcrypt.BCrypt;
 
 @SuppressWarnings("serial")
 public class Authentication extends HttpServlet {
@@ -40,7 +41,8 @@ public class Authentication extends HttpServlet {
     testerList = query.list();
     int dontRedirect = 0;
     if (!testerList.isEmpty()) {
-      if (testerList.get(0).getLoginPassword().equals(password)) {
+      // Checking if password matches hash
+      if (BCrypt.checkpw(password, testerList.get(0).getLoginPassword())) {
         newTester = testerList.get(0);
       } else {
         //wrong password 
@@ -50,6 +52,8 @@ public class Authentication extends HttpServlet {
       }
     } else {
 
+      // hashing new password
+      password = BCrypt.hashpw(password, BCrypt.gensalt(5));
       // Creating new tester/user
       newTester.setLoginUsername(username);
       newTester.setLoginPassword(password);

--- a/src/main/java/org/immregistries/ehr/servlet/PatientRecord.java
+++ b/src/main/java/org/immregistries/ehr/servlet/PatientRecord.java
@@ -45,7 +45,7 @@ public class PatientRecord extends HttpServlet {
         List<Patient> patientList = null;
         List<VaccinationEvent> entryList = null;
         if(req.getParameter("paramPatientId")!=null) {
-        Query query = dataSession.createQuery("from Patient where patientId=?");
+        Query query = dataSession.createQuery("from Patient where patientId=? and facilityId");
         query.setParameter(0, Integer.parseInt(req.getParameter("paramPatientId")));
         patientList = query.list();
         patient = patientList.get(0);

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee;http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+<web-app 
+  xmlns="http://java.sun.com/xml/ns/j2ee" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee;http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
   version="2.4">
 
   <display-name>EHR-Sandbox</display-name>
@@ -125,4 +128,13 @@
   	<servlet-name>Authentication</servlet-name>
   	<url-pattern>/authentication</url-pattern>
   </servlet-mapping>
+
+  <filter>
+        <filter-name>loginFilter</filter-name>
+        <filter-class>org.immregistries.ehr.LoginFilter</filter-class>
+  </filter>
+  <filter-mapping>
+      <filter-name>loginFilter</filter-name>
+      <url-pattern>/*</url-pattern>
+  </filter-mapping>
 </web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -5,7 +5,8 @@
   <display-name>EHR-Sandbox</display-name>
   
   <welcome-file-list>  
-  	<welcome-file>org.immregistries.ehr.servlet.Authentication</welcome-file></welcome-file-list>
+  	<welcome-file>authentication</welcome-file>
+  </welcome-file-list>
 
   <servlet>
     <servlet-name>home</servlet-name>


### PR DESCRIPTION
I added a filter to redirect non authenticated users to the authentication page, and I used JBcrypt to hash the passwords before sending them to the  database. 
Databases should be truncated after this change in order to keep using the same testers/users credentials