### PR TITLE
Add missing java spec dependencies

### DIFF
--- a/EHR-Sandbox-Api/pom.xml
+++ b/EHR-Sandbox-Api/pom.xml
@@ -133,6 +133,11 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.4.0-b180830.0359</version>


### PR DESCRIPTION
After the move from java 8 to 9, the javax annotations are no longer included in the java runtime.  Adding this dependency should resolve issues encountered with running EHR-API portion with a modern runtime.